### PR TITLE
Optional generate 32/64-bit universal lib on mac.

### DIFF
--- a/gyp/lua.gyp
+++ b/gyp/lua.gyp
@@ -29,6 +29,7 @@
       '<@(lua_specific_compiler_flags)',
       '<@(compiler_flags)'
     ],
+    'target_archs%': ['$(ARCHS_STANDARD_32_64_BIT)'],
   },
 
 
@@ -100,6 +101,9 @@
     [ 
       "OS=='mac'", 
       {
+        'xcode_settings': {
+          'ARCHS': ['<@(target_archs)'],
+        },
         'target_defaults': {
           'defines': [
             'LUA_USE_MACOSX'


### PR DESCRIPTION
We need to generate a 32-bit dylib our Unity editor plugin.
We currently force a 32-bit build via a script that runs xcodebuild.
However, we also want to share build products between the Xcode Mac App
build (via Xcode IDE). In order to do this, we need to allow a universal
build on mac, so that we have the option to generate fat libs.

Rather than hard-code this value, we now allow it to be set through
gyp by defining the archs set during configuration.
